### PR TITLE
Support newer version of mosquitto

### DIFF
--- a/config-maps/config-mq-confgmap.yaml
+++ b/config-maps/config-mq-confgmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mosquitto-configmap
+data:
+  mosquitto.conf: |-
+    listener 1883
+    allow_anonymous true

--- a/deployments/mosquitto-deployment.yaml
+++ b/deployments/mosquitto-deployment.yaml
@@ -30,7 +30,14 @@ spec:
         ports:
         - containerPort: 1883
         resources: {}
+        volumeMounts:
+        - name: mosquitto-config
+          mountPath: /mosquitto/config/mosquitto.conf
+          subPath: mosquitto.conf
       restartPolicy: Always
       serviceAccountName: ""
-      volumes: null
+      volumes:
+      - name: mosquitto-config
+        configMap:
+          name: mosquitto-configmap
 status: {}


### PR DESCRIPTION
Newer versions of mosquitto only listen on localhost - the configMap ensures the old behaviour. 